### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/react-hooks-context/src/Form/DatosUsuario/index.js
+++ b/react-hooks-context/src/Form/DatosUsuario/index.js
@@ -23,7 +23,7 @@ const DatosUsuario = ({ updateStep }) => {
         e.preventDefault();
         if (email.valid && password.valid) {
           console.log("Siguiente formulario");
-          console.log(email, password);
+          console.log({ email: email, password: "REDACTED" });
           updateStep(1);
         } else {
           console.log("No hacer nada");


### PR DESCRIPTION
Fixes [https://github.com/Juan-Camilo-Sanchez-Echeverri/React-ONE/security/code-scanning/1](https://github.com/Juan-Camilo-Sanchez-Echeverri/React-ONE/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead of logging the actual password, we can log a placeholder or a message indicating that the password was received without revealing its value. This way, we maintain the functionality of logging for debugging purposes without exposing sensitive information.

We will modify the code in the `onSubmit` function to avoid logging the actual password. Specifically, we will replace the line that logs the `password` variable with a message indicating that the password was received.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
